### PR TITLE
Fixed regex to allow spaces in genre name

### DIFF
--- a/src/app/music-map/genre-search.tsx
+++ b/src/app/music-map/genre-search.tsx
@@ -22,7 +22,7 @@ export default function GenreSearch({
     // return the first 3 results from the record based on a cleaned (alphanum) user input
     return allGenres
       .filter((g) =>
-        g.name.replace(/[^a-zA-Z0-9]/g, "").includes(searchTerm.toLowerCase())
+        g.name.replace(/[^a-zA-Z0-9 ]/g, "").includes(searchTerm.toLowerCase())
       )
       .slice(0, 3);
   }, [searchTerm]);


### PR DESCRIPTION
forgot to allow for spaces to ensure user can search for genres like "latin ..."